### PR TITLE
Should we move tag values from aggregations to views?

### DIFF
--- a/core/src/main/java/com/google/instrumentation/stats/DistributionAggregation.java
+++ b/core/src/main/java/com/google/instrumentation/stats/DistributionAggregation.java
@@ -33,27 +33,17 @@ public final class DistributionAggregation {
    * Constructs a new {@link DistributionAggregation}.
    */
   public static final DistributionAggregation create(
-      long count, double mean, double sum, Range range, List<Tag> tags) {
-    return new DistributionAggregation(count, mean, sum, range, tags, null);
+      long count, double mean, double sum, Range range) {
+    return new DistributionAggregation(count, mean, sum, range, null);
   }
 
   /**
    * Constructs a new {@link DistributionAggregation} with the optional {@code bucketCount}s.
    */
   public static final DistributionAggregation create(
-      long count, double mean, double sum, Range range, List<Tag> tags, List<Long> bucketCounts) {
-    return new DistributionAggregation(count, mean, sum, range, tags,
+      long count, double mean, double sum, Range range, List<Long> bucketCounts) {
+    return new DistributionAggregation(count, mean, sum, range,
         Collections.unmodifiableList(new ArrayList<Long>(bucketCounts)));
-  }
-
-  /**
-   * {@link Tag}s associated with this {@link DistributionAggregation}.
-   *
-   * <p>Note: The returned list is unmodifiable, attempts to update it will throw an
-   * UnsupportedOperationException.
-   */
-  public final List<Tag> getTags() {
-    return tags;
   }
 
   /**
@@ -116,17 +106,14 @@ public final class DistributionAggregation {
   private final double mean;
   private final double sum;
   private final Range range;
-  private final List<Tag> tags;
   private final List<Long> bucketCounts;
 
   private DistributionAggregation(
-      long count, double mean, double sum, Range range, List<Tag> tags,
-      @Nullable List<Long> bucketCounts) {
+      long count, double mean, double sum, Range range, @Nullable List<Long> bucketCounts) {
     this.count = count;
     this.mean = mean;
     this.sum = sum;
     this.range = range;
-    this.tags = tags;
     this.bucketCounts = bucketCounts;
   }
 

--- a/core/src/main/java/com/google/instrumentation/stats/IntervalAggregation.java
+++ b/core/src/main/java/com/google/instrumentation/stats/IntervalAggregation.java
@@ -27,18 +27,8 @@ public final class IntervalAggregation {
    * Constructs new {@link IntervalAggregation}.
    * TODO(dpo): Determine what we should do it intervals is empty.
    */
-  public static final IntervalAggregation create(List<Tag> tags, List<Interval> intervals) {
-    return new IntervalAggregation(tags, intervals);
-  }
-
-  /**
-   * {@link Tag}s associated with this aggregation.
-   *
-   * <p>Note: The returned list is unmodifiable, attempts to update it will throw an
-   * UnsupportedOperationException.
-   */
-  public final List<Tag> getTags() {
-    return tags;
+  public static final IntervalAggregation create(List<Interval> intervals) {
+    return new IntervalAggregation(intervals);
   }
 
   /**
@@ -48,11 +38,9 @@ public final class IntervalAggregation {
     return intervals;
   }
 
-  private final List<Tag> tags;
   private final List<Interval> intervals;
 
-  private IntervalAggregation(List<Tag> tags, List<Interval> intervals) {
-    this.tags = tags;
+  private IntervalAggregation(List<Interval> intervals) {
     this.intervals = Collections.unmodifiableList(new ArrayList<Interval>(intervals));
   }
 

--- a/core/src/main/java/com/google/instrumentation/stats/View.java
+++ b/core/src/main/java/com/google/instrumentation/stats/View.java
@@ -19,6 +19,7 @@ import com.google.instrumentation.stats.ViewDescriptor.DistributionViewDescripto
 import com.google.instrumentation.stats.ViewDescriptor.IntervalViewDescriptor;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * The aggregated data for a particular {@link ViewDescriptor}.
@@ -47,18 +48,23 @@ public abstract class View {
     /**
      * Constructs a new {@link DistributionView}.
      */
-    public static DistributionView create(DistributionViewDescriptor distributionViewDescriptor,
-        List<DistributionAggregation> distributionAggregations, Timestamp start, Timestamp end) {
+    public static DistributionView create(
+        DistributionViewDescriptor distributionViewDescriptor,
+        Map<List<TagValue>, DistributionAggregation> distributionAggregations,
+        Timestamp start,
+        Timestamp end) {
       return new DistributionView(distributionViewDescriptor, distributionAggregations, start, end);
     }
 
     /**
      * The {@link DistributionAggregation}s associated with this {@link DistributionView}.
+     * Each one is associated with a different set of tag values. The tag value at index n
+     * corresponds to the tag key at index n in the associated ViewDescriptor.
      *
-     * <p>Note: The returned list is unmodifiable, attempts to update it will throw an
+     * <p>Note: The returned map is unmodifiable, attempts to update it will throw an
      * UnsupportedOperationException.
      */
-    public List<DistributionAggregation> getDistributionAggregations() {
+    public Map<List<TagValue>, DistributionAggregation> getDistributionAggregations() {
       return distributionAggregations;
     }
 
@@ -89,12 +95,15 @@ public abstract class View {
     }
 
     private final DistributionViewDescriptor distributionViewDescriptor;
-    private final List<DistributionAggregation> distributionAggregations;
+    private final Map<List<TagValue>, DistributionAggregation> distributionAggregations;
     private final Timestamp start;
     private final Timestamp end;
 
-    private DistributionView(DistributionViewDescriptor distributionViewDescriptor,
-        List<DistributionAggregation> distributionAggregations, Timestamp start, Timestamp end) {
+    private DistributionView(
+        DistributionViewDescriptor distributionViewDescriptor,
+        Map<List<TagValue>, DistributionAggregation> distributionAggregations,
+        Timestamp start,
+        Timestamp end) {
       this.distributionViewDescriptor = distributionViewDescriptor;
       this.distributionAggregations = distributionAggregations;
       this.start = start;
@@ -110,17 +119,19 @@ public abstract class View {
      * Constructs a new {@link IntervalView}.
      */
     public static IntervalView create(IntervalViewDescriptor intervalViewDescriptor,
-        List<IntervalAggregation> intervalAggregations) {
+        Map<List<TagValue>, IntervalAggregation> intervalAggregations) {
       return new IntervalView(intervalViewDescriptor, intervalAggregations);
     }
 
     /**
      * The {@link IntervalAggregation}s associated with this {@link IntervalView}.
+     * Each one is associated with a different set of tag values. The tag value at index n
+     * corresponds to the tag key at index n in the associated ViewDescriptor.
      *
-     * <p>Note: The returned list is unmodifiable, attempts to update it will throw an
+     * <p>Note: The returned map is unmodifiable, attempts to update it will throw an
      * UnsupportedOperationException.
      */
-    public List<IntervalAggregation> getIntervalAggregations() {
+    public Map<List<TagValue>, IntervalAggregation> getIntervalAggregations() {
       return intervalAggregations;
     }
 
@@ -137,10 +148,10 @@ public abstract class View {
     }
 
     private final IntervalViewDescriptor intervalViewDescriptor;
-    private final List<IntervalAggregation> intervalAggregations;
+    private final Map<List<TagValue>, IntervalAggregation> intervalAggregations;
 
     private IntervalView(IntervalViewDescriptor intervalViewDescriptor,
-        List<IntervalAggregation> intervalAggregations) {
+        Map<List<TagValue>, IntervalAggregation> intervalAggregations) {
       this.intervalViewDescriptor = intervalViewDescriptor;
       this.intervalAggregations = intervalAggregations;
     }


### PR DESCRIPTION
I thought of this change while we were discussing design last week.  Instead of storing a list of tags in the aggregation classes, we could store a map from tags to aggregations in `View`.  I think this change is more consistent with xDescriptor being the schema for x.  In this commit, ViewDescriptor contains the tag keys, and View contains the tag values.  Do you think this would simplify the API?  I used `Map`, for simplicity, but there are other ways to pair tags with aggregations.

/cc @dinooliva @a-veitch @acetechnologist