### PR TITLE
Add Parser for parsing view constants proto binary.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,7 @@ include ":instrumentation-java-all"
 include ":instrumentation-java-benchmarks"
 include ":instrumentation-java-core"
 include ":instrumentation-java-core-impl"
+include ":instrumentation-java-core-util"
 include ":proto"
 include ":shared"
 
@@ -10,6 +11,7 @@ project(':instrumentation-java-all').projectDir = "$rootDir/all" as File
 project(':instrumentation-java-benchmarks').projectDir = "$rootDir/benchmarks" as File
 project(':instrumentation-java-core').projectDir = "$rootDir/core" as File
 project(':instrumentation-java-core-impl').projectDir = "$rootDir/core_impl" as File
+project(':instrumentation-java-core-util').projectDir = "$rootDir/util" as File
 project(':proto').projectDir = "$rootDir/proto" as File
 project(':shared').projectDir = "$rootDir/shared" as File
 

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -1,0 +1,10 @@
+description = 'Instrumentation Core Util'
+
+dependencies {
+    compile project(':instrumentation-java-core'),
+            project(':proto'),
+            libraries.disruptor,
+            libraries.guava
+
+    signature "org.codehaus.mojo.signature:java16:+@signature"
+}

--- a/util/src/main/java/com/google/instrumentation/stats/RpcConstantsFromProto.java
+++ b/util/src/main/java/com/google/instrumentation/stats/RpcConstantsFromProto.java
@@ -1,0 +1,193 @@
+package com.google.instrumentation.stats;
+
+import com.google.instrumentation.stats.ViewDescriptor.DistributionViewDescriptor;
+import com.google.instrumentation.stats.ViewDescriptor.IntervalViewDescriptor;
+import java.util.Map;
+
+/**
+ * Constants for collecting rpc stats.
+ */
+public final class RpcConstantsFromProto {
+
+  private static final ViewConstantsProtoBinaryParser parser = new ViewConstantsProtoBinaryParser(
+      "../proto/stats/rpc_constants.pb");
+  private static final Map<String, MeasurementDescriptor> measurementDescriptorMap = parser
+      .getMeasurementDescriptorMap();
+  private static final Map<String, ViewDescriptor> viewDescriptorMap = parser
+      .getViewDescriptorMap();
+
+  // RPC client {@link MeasurementDescriptor}s.
+  public static final MeasurementDescriptor RPC_CLIENT_ERROR_COUNT =
+      measurementDescriptorMap.get("grpc.io/client/error_count");
+  public static final MeasurementDescriptor RPC_CLIENT_REQUEST_BYTES =
+      measurementDescriptorMap.get("grpc.io/client/request_bytes");
+  public static final MeasurementDescriptor RPC_CLIENT_RESPONSE_BYTES =
+      measurementDescriptorMap.get("grpc.io/client/response_bytes");
+  public static final MeasurementDescriptor RPC_CLIENT_ROUNDTRIP_LATENCY =
+      measurementDescriptorMap.get("grpc.io/client/roundtrip_latency");
+  public static final MeasurementDescriptor RPC_CLIENT_SERVER_ELAPSED_TIME =
+      measurementDescriptorMap.get("grpc.io/client/server_elapsed_time");
+  public static final MeasurementDescriptor RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES =
+      measurementDescriptorMap.get("grpc.io/client/uncompressed_request_bytes");
+  public static final MeasurementDescriptor RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES =
+      measurementDescriptorMap.get("grpc.io/client/uncompressed_response_bytes");
+  public static final MeasurementDescriptor RPC_CLIENT_STARTED_COUNT =
+      measurementDescriptorMap.get("grpc.io/client/started_count");
+  public static final MeasurementDescriptor RPC_CLIENT_FINISHED_COUNT =
+      measurementDescriptorMap.get("grpc.io/client/finished_count");
+  public static final MeasurementDescriptor RPC_CLIENT_REQUEST_COUNT =
+      measurementDescriptorMap.get("grpc.io/client/request_count");
+  public static final MeasurementDescriptor RPC_CLIENT_RESPONSE_COUNT =
+      measurementDescriptorMap.get("grpc.io/client/response_count");
+
+
+  // RPC server {@link MeasurementDescriptor}s.
+  public static final MeasurementDescriptor RPC_SERVER_ERROR_COUNT =
+      measurementDescriptorMap.get("grpc.io/server/error_count");
+  public static final MeasurementDescriptor RPC_SERVER_REQUEST_BYTES =
+      measurementDescriptorMap.get("grpc.io/server/request_bytes");
+  public static final MeasurementDescriptor RPC_SERVER_RESPONSE_BYTES =
+      measurementDescriptorMap.get("grpc.io/server/response_bytes");
+  public static final MeasurementDescriptor RPC_SERVER_LATENCY =
+      measurementDescriptorMap.get("grpc.io/server/server_latency");
+  public static final MeasurementDescriptor RPC_SERVER_SERVER_ELAPSED_TIME =
+      measurementDescriptorMap.get("grpc.io/server/server_elapsed_time");
+  public static final MeasurementDescriptor RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES =
+      measurementDescriptorMap.get("grpc.io/server/uncompressed_request_bytes");
+  public static final MeasurementDescriptor RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES =
+      measurementDescriptorMap.get("grpc.io/server/uncompressed_response_bytes");
+  public static final MeasurementDescriptor RPC_SERVER_STARTED_COUNT =
+      measurementDescriptorMap.get("grpc.io/server/started_count");
+  public static final MeasurementDescriptor RPC_SERVER_FINISHED_COUNT =
+      measurementDescriptorMap.get("grpc.io/server/finished_count");
+  public static final MeasurementDescriptor RPC_SERVER_REQUEST_COUNT =
+      measurementDescriptorMap.get("grpc.io/server/request_count");
+  public static final MeasurementDescriptor RPC_SERVER_RESPONSE_COUNT =
+      measurementDescriptorMap.get("grpc.io/server/response_count");
+
+  // Rpc client {@link ViewDescriptor}s.
+  public static final DistributionViewDescriptor RPC_CLIENT_ERROR_COUNT_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/error_count/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/roundtrip_latency/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_CLIENT_SERVER_ELAPSED_TIME_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/server_elapsed_time/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_CLIENT_REQUEST_BYTES_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/request_bytes/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_CLIENT_RESPONSE_BYTES_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/response_bytes/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap
+              .get("grpc.io/client/uncompressed_request_bytes/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap
+              .get("grpc.io/client/uncompressed_response_bytes/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_CLIENT_REQUEST_COUNT_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/request_count/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_CLIENT_RESPONSE_COUNT_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/response_count/distribution_cumulative");
+
+
+  // Rpc server {@link ViewDescriptor}s.
+  public static final DistributionViewDescriptor RPC_SERVER_ERROR_COUNT_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/error_count/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_SERVER_LATENCY_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/server_latency/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_SERVER_SERVER_ELAPSED_TIME_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/server_elapsed_time/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_SERVER_REQUEST_BYTES_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/request_bytes/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_SERVER_RESPONSE_BYTES_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/response_bytes/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap
+              .get("grpc.io/server/uncompressed_request_bytes/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap
+              .get("grpc.io/server/uncompressed_response_bytes/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_SERVER_REQUEST_COUNT_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/request_count/distribution_cumulative");
+  public static final DistributionViewDescriptor RPC_SERVER_RESPONSE_COUNT_VIEW =
+      (DistributionViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/response_count/distribution_cumulative");
+
+  // RPC client {@link IntervalViewDescriptor}s.
+  public static final IntervalViewDescriptor RPC_CLIENT_ROUNDTRIP_LATENCY_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/roundtrip_latency/interval");
+  public static final IntervalViewDescriptor RPC_CLIENT_REQUEST_BYTES_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/request_bytes/interval");
+  public static final IntervalViewDescriptor RPC_CLIENT_RESPONSE_BYTES_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/response_bytes/interval");
+  public static final IntervalViewDescriptor RPC_CLIENT_ERROR_COUNT_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/error_count/interval");
+  public static final IntervalViewDescriptor RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/uncompressed_request_bytes/interval");
+  public static final IntervalViewDescriptor RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/uncompressed_response_bytes/interval");
+  public static final IntervalViewDescriptor RPC_CLIENT_SERVER_ELAPSED_TIME_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/server_elapsed_time/interval");
+  public static final IntervalViewDescriptor RPC_CLIENT_STARTED_COUNT_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/started_count/interval");
+  public static final IntervalViewDescriptor RPC_CLIENT_FINISHED_COUNT_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/client/finished_count/interval");
+
+  // RPC server {@link IntervalViewDescriptor}s.
+  public static final IntervalViewDescriptor RPC_SERVER_SERVER_LATENCY_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/server_latency/interval");
+  public static final IntervalViewDescriptor RPC_SERVER_REQUEST_BYTES_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/request_bytes/interval");
+  public static final IntervalViewDescriptor RPC_SERVER_RESPONSE_BYTES_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/response_bytes/interval");
+  public static final IntervalViewDescriptor RPC_SERVER_ERROR_COUNT_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/error_count/interval");
+  public static final IntervalViewDescriptor RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/uncompressed_request_bytes/interval");
+  public static final IntervalViewDescriptor RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/uncompressed_response_bytes/interval");
+  public static final IntervalViewDescriptor RPC_SERVER_SERVER_ELAPSED_TIME_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/server_elapsed_time/interval");
+  public static final IntervalViewDescriptor RPC_SERVER_STARTED_COUNT_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/started_count/interval");
+  public static final IntervalViewDescriptor RPC_SERVER_FINISHED_COUNT_INTERVAL_VIEW =
+      (IntervalViewDescriptor)
+          viewDescriptorMap.get("grpc.io/server/finished_count/interval");
+
+  // Visible for testing.
+  RpcConstantsFromProto() {
+    throw new AssertionError();
+  }
+}

--- a/util/src/main/java/com/google/instrumentation/stats/RpcConstantsFromProto.java
+++ b/util/src/main/java/com/google/instrumentation/stats/RpcConstantsFromProto.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2016, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.instrumentation.stats;
 
 import com.google.instrumentation.stats.ViewDescriptor.DistributionViewDescriptor;
@@ -50,8 +63,6 @@ public final class RpcConstantsFromProto {
       measurementDescriptorMap.get("grpc.io/server/response_bytes");
   public static final MeasurementDescriptor RPC_SERVER_LATENCY =
       measurementDescriptorMap.get("grpc.io/server/server_latency");
-  public static final MeasurementDescriptor RPC_SERVER_SERVER_ELAPSED_TIME =
-      measurementDescriptorMap.get("grpc.io/server/server_elapsed_time");
   public static final MeasurementDescriptor RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES =
       measurementDescriptorMap.get("grpc.io/server/uncompressed_request_bytes");
   public static final MeasurementDescriptor RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES =
@@ -104,9 +115,6 @@ public final class RpcConstantsFromProto {
   public static final DistributionViewDescriptor RPC_SERVER_LATENCY_VIEW =
       (DistributionViewDescriptor)
           viewDescriptorMap.get("grpc.io/server/server_latency/distribution_cumulative");
-  public static final DistributionViewDescriptor RPC_SERVER_SERVER_ELAPSED_TIME_VIEW =
-      (DistributionViewDescriptor)
-          viewDescriptorMap.get("grpc.io/server/server_elapsed_time/distribution_cumulative");
   public static final DistributionViewDescriptor RPC_SERVER_REQUEST_BYTES_VIEW =
       (DistributionViewDescriptor)
           viewDescriptorMap.get("grpc.io/server/request_bytes/distribution_cumulative");
@@ -176,9 +184,6 @@ public final class RpcConstantsFromProto {
   public static final IntervalViewDescriptor RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_INTERVAL_VIEW =
       (IntervalViewDescriptor)
           viewDescriptorMap.get("grpc.io/server/uncompressed_response_bytes/interval");
-  public static final IntervalViewDescriptor RPC_SERVER_SERVER_ELAPSED_TIME_INTERVAL_VIEW =
-      (IntervalViewDescriptor)
-          viewDescriptorMap.get("grpc.io/server/server_elapsed_time/interval");
   public static final IntervalViewDescriptor RPC_SERVER_STARTED_COUNT_INTERVAL_VIEW =
       (IntervalViewDescriptor)
           viewDescriptorMap.get("grpc.io/server/started_count/interval");

--- a/util/src/main/java/com/google/instrumentation/stats/ViewConstantsProtoBinaryParser.java
+++ b/util/src/main/java/com/google/instrumentation/stats/ViewConstantsProtoBinaryParser.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2016, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.stats;
+
+import com.google.common.io.Files;
+import com.google.instrumentation.common.Duration;
+import com.google.instrumentation.stats.MeasurementDescriptor.BasicUnit;
+import com.google.instrumentation.stats.MeasurementDescriptor.MeasurementUnit;
+import com.google.instrumentation.stats.ViewDescriptor.DistributionViewDescriptor;
+import com.google.instrumentation.stats.ViewDescriptor.IntervalViewDescriptor;
+import com.google.instrumentation.stats.proto.CensusProto;
+import com.google.instrumentation.stats.proto.ViewDescriptorConstantsProto;
+import com.google.instrumentation.stats.proto.ViewDescriptorConstantsProto.ViewDescriptorConstants;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A parser class used to translate view constants from proto binary format into POJOs.
+ */
+public class ViewConstantsProtoBinaryParser {
+
+  private final ViewDescriptorConstantsProto.ViewDescriptorConstants viewDescriptorConstants;
+
+  // Used to quickly look up specific measurement descriptor associated with some view descriptor.
+  private Map<String, MeasurementDescriptor> measurementDescriptorLocalMap = null;
+
+  /**
+   * @param protoBinaryFilePath is the absolute path of the view constants proto binary file.
+   */
+  public ViewConstantsProtoBinaryParser(String protoBinaryFilePath) {
+    final File protoBinaryFile = new File(protoBinaryFilePath);
+    try {
+      byte[] protoBinaryBytes = Files.toByteArray(protoBinaryFile);
+      this.viewDescriptorConstants = ViewDescriptorConstants.parseFrom(protoBinaryBytes);
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static final MeasurementDescriptor toMeasurementDescriptor(
+      CensusProto.MeasurementDescriptor protoMeasurementDescriptor) {
+    List<BasicUnit> numerators = new ArrayList<BasicUnit>();
+    List<BasicUnit> denominators = new ArrayList<BasicUnit>();
+    for (CensusProto.MeasurementDescriptor.BasicUnit protoBasicUnit :
+        protoMeasurementDescriptor.getUnit().getNumeratorsList()) {
+      numerators.add(BasicUnit.valueOf(protoBasicUnit.toString()));
+    }
+    for (CensusProto.MeasurementDescriptor.BasicUnit protoBasicUnit :
+        protoMeasurementDescriptor.getUnit().getDenominatorsList()) {
+      denominators.add(BasicUnit.valueOf(protoBasicUnit.toString()));
+    }
+
+    return MeasurementDescriptor.create(
+        protoMeasurementDescriptor.getName(),
+        protoMeasurementDescriptor.getDescription(),
+        MeasurementUnit.create(
+            protoMeasurementDescriptor.getUnit().getPower10(), numerators, denominators));
+  }
+
+  private static final ViewDescriptor toViewDescriptor(
+      CensusProto.ViewDescriptor protoViewDescriptor,
+      Map<String, MeasurementDescriptor> measurementDescriptorMap) {
+    final ViewDescriptor viewDescriptor;
+    if (protoViewDescriptor.getName().endsWith("interval")) {
+      viewDescriptor = IntervalViewDescriptor.create(
+          protoViewDescriptor.getName(),
+          protoViewDescriptor.getDescription(),
+          measurementDescriptorMap.get(protoViewDescriptor.getMeasurementDescriptorName()),
+          toIntervalAggregationDescriptor(protoViewDescriptor.getIntervalAggregation()),
+          toTagKeys(protoViewDescriptor.getTagKeysList()));
+    } else {
+      viewDescriptor = DistributionViewDescriptor.create(
+          protoViewDescriptor.getName(),
+          protoViewDescriptor.getDescription(),
+          measurementDescriptorMap.get(protoViewDescriptor.getMeasurementDescriptorName()),
+          toDistributionViewDescriptor(protoViewDescriptor.getDistributionAggregation()),
+          toTagKeys(protoViewDescriptor.getTagKeysList()));
+    }
+    return viewDescriptor;
+  }
+
+  private static final IntervalAggregationDescriptor toIntervalAggregationDescriptor(
+      CensusProto.IntervalAggregationDescriptor protoIntervalAggregationDescriptor) {
+    List<Duration> durations = new ArrayList<Duration>();
+    for (CensusProto.Duration protoDuration :
+        protoIntervalAggregationDescriptor.getIntervalSizesList()) {
+      durations.add(Duration.create(protoDuration.getSeconds(), protoDuration.getNanos()));
+    }
+
+    int numSubIntervals = protoIntervalAggregationDescriptor.getNSubIntervals();
+    if (numSubIntervals < 2 || numSubIntervals > 20) {
+      return IntervalAggregationDescriptor.create(durations);
+    } else {
+      return IntervalAggregationDescriptor.create(
+          protoIntervalAggregationDescriptor.getNSubIntervals(), durations);
+    }
+  }
+
+  private static final DistributionAggregationDescriptor toDistributionViewDescriptor(
+      CensusProto.DistributionAggregationDescriptor protoDistributionAggregationDescriptor) {
+    return DistributionAggregationDescriptor.create(
+        protoDistributionAggregationDescriptor.getBucketBoundsList());
+  }
+
+  private static final List<TagKey> toTagKeys(com.google.protobuf.ProtocolStringList protoTagKeys) {
+    List<TagKey> tagKeys = new ArrayList<TagKey>();
+    for (String tagKeyStr : protoTagKeys) {
+      tagKeys.add(TagKey.create(tagKeyStr));
+    }
+    return tagKeys;
+  }
+
+  /**
+   * @return a map, where key is measurement descriptor name, and value is the descriptor.
+   */
+  public final Map<String, MeasurementDescriptor> getMeasurementDescriptorMap() {
+    if (this.measurementDescriptorLocalMap != null) {
+      return this.measurementDescriptorLocalMap;
+    }
+
+    Map<String, MeasurementDescriptor> measurementDescriptorMap =
+        new HashMap<String, MeasurementDescriptor>();
+    for (CensusProto.MeasurementDescriptor protoMeasurementDescriptor :
+        viewDescriptorConstants.getMeasurementDescriptorList()) {
+      measurementDescriptorMap.put(protoMeasurementDescriptor.getName(),
+          toMeasurementDescriptor(protoMeasurementDescriptor));
+    }
+    this.measurementDescriptorLocalMap = measurementDescriptorMap;
+    return measurementDescriptorMap;
+  }
+
+  /**
+   * @return a map, where key is view descriptor name, and value is the descriptor.
+   */
+  public final Map<String, ViewDescriptor> getViewDescriptorMap() {
+    if (this.measurementDescriptorLocalMap == null) {
+      // Initialize the local map for measurement descriptor if needed.
+      getMeasurementDescriptorMap();
+    }
+
+    Map<String, ViewDescriptor> viewDescriptorMap = new HashMap<String, ViewDescriptor>();
+    for (CensusProto.ViewDescriptor protoViewDescriptor :
+        viewDescriptorConstants.getViewDescriptorList()) {
+      viewDescriptorMap.put(protoViewDescriptor.getName(),
+          toViewDescriptor(protoViewDescriptor, this.measurementDescriptorLocalMap));
+    }
+    return viewDescriptorMap;
+  }
+}

--- a/util/src/test/java/com/google/instrumentation/stats/RpcConstantsFromProtoTest.java
+++ b/util/src/test/java/com/google/instrumentation/stats/RpcConstantsFromProtoTest.java
@@ -1,0 +1,35 @@
+package com.google.instrumentation.stats;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for RpcConstantsFromProto.
+ */
+@RunWith(JUnit4.class)
+public class RpcConstantsFromProtoTest {
+  @Test
+  public void testConstants() {
+    assertThat(RpcConstantsFromProto.RPC_CLIENT_ERROR_COUNT).isNotNull();
+    assertThat(RpcConstantsFromProto.RPC_CLIENT_ROUNDTRIP_LATENCY).isNotNull();
+    assertThat(RpcConstantsFromProto.RPC_CLIENT_REQUEST_BYTES).isNotNull();
+    assertThat(RpcConstantsFromProto.RPC_CLIENT_RESPONSE_BYTES).isNotNull();
+    assertThat(RpcConstantsFromProto.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES).isNotNull();
+    assertThat(RpcConstantsFromProto.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES).isNotNull();
+
+    assertThat(RpcConstantsFromProto.RPC_SERVER_ERROR_COUNT).isNotNull();
+    assertThat(RpcConstantsFromProto.RPC_SERVER_REQUEST_BYTES).isNotNull();
+    assertThat(RpcConstantsFromProto.RPC_SERVER_RESPONSE_BYTES).isNotNull();
+    assertThat(RpcConstantsFromProto.RPC_SERVER_LATENCY).isNotNull();
+    assertThat(RpcConstantsFromProto.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES).isNotNull();
+    assertThat(RpcConstantsFromProto.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES).isNotNull();
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testConstructor() {
+    new RpcConstantsFromProto();
+  }
+}

--- a/util/src/test/java/com/google/instrumentation/stats/RpcConstantsFromProtoTest.java
+++ b/util/src/test/java/com/google/instrumentation/stats/RpcConstantsFromProtoTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2016, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.instrumentation.stats;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/util/src/test/java/com/google/instrumentation/stats/ViewConstantsProtoBinaryParserTest.java
+++ b/util/src/test/java/com/google/instrumentation/stats/ViewConstantsProtoBinaryParserTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.stats;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Map.Entry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for ViewConstantsProtoBinaryParser.
+ */
+@RunWith(JUnit4.class)
+public final class ViewConstantsProtoBinaryParserTest {
+
+  private static final ViewConstantsProtoBinaryParser parser = new ViewConstantsProtoBinaryParser(
+      "../proto/stats/rpc_constants.pb");
+  private static final int GRPC_MEASUREMENT_DESCRIPTOR_COUNT = 22;
+  private static final int GRPC_VIEW_DESCRIPTOR_COUNT = 36;
+
+  @Test(expected = AssertionError.class)
+  public void testConstructorFileNotFound() {
+    ViewConstantsProtoBinaryParser invalidParser = new ViewConstantsProtoBinaryParser("NOT_EXIST");
+  }
+
+  @Test
+  public void testGetMeasurementDescriptorMap() {
+    assertThat(parser.getMeasurementDescriptorMap()).hasSize(GRPC_MEASUREMENT_DESCRIPTOR_COUNT);
+    for (Entry<String, MeasurementDescriptor> entry :
+        parser.getMeasurementDescriptorMap().entrySet()) {
+      assertThat(entry.getValue().getName()).isEqualTo(entry.getKey());
+      assertThat(entry.getValue().getDescription()).isNotEmpty();
+      assertThat(entry.getValue().getUnit()).isNotNull();
+    }
+  }
+
+  @Test
+  public void testGetViewDescriptorMap() {
+    assertThat(parser.getViewDescriptorMap()).hasSize(GRPC_VIEW_DESCRIPTOR_COUNT);
+    for (Entry<String, ViewDescriptor> entry : parser.getViewDescriptorMap().entrySet()) {
+      assertThat(entry.getValue().getName()).isEqualTo(entry.getKey());
+      assertThat(entry.getValue().getDescription()).isNotEmpty();
+      assertThat(entry.getValue().getMeasurementDescriptor()).isNotNull();
+      assertThat(entry.getValue().getTagKeys()).isNotEmpty();
+    }
+  }
+}


### PR DESCRIPTION
This PR is dependent on PR https://github.com/google/instrumentation-proto/pull/24.

Since stats-core cannot depend on proto, I used an independent library util to do the translation (from proto binary to POJOs). Currently I'm assuming that we could separate the RPC constants from stats-core, however if those constants absolutely need to reside in stats-core, I'll try other alternative approaches (converting to JSON, etc.).