### PR TITLE
No longer override projectDirs.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -5,12 +5,6 @@ include ":core_impl"
 include ":core_impl_java"
 include ":core_impl_android"
 
-project(':all').projectDir = "$rootDir/all" as File
-project(':core').projectDir = "$rootDir/core" as File
-project(':core_impl').projectDir = "$rootDir/core_impl" as File
-project(':core_impl_java').projectDir = "$rootDir/core_impl_java" as File
-project(':core_impl_android').projectDir = "$rootDir/core_impl_android" as File
-
 // Java8 projects only
 if (JavaVersion.current().isJava8Compatible()) {
     include ":examples"


### PR DESCRIPTION
No longer override projectDirs now that the gradle subproject names match the directory names.