### PR TITLE
Resolve all the Distribution TODO's

### DIFF
--- a/core/src/main/java/com/google/instrumentation/stats/BucketBoundaries.java
+++ b/core/src/main/java/com/google/instrumentation/stats/BucketBoundaries.java
@@ -33,17 +33,19 @@ public abstract class BucketBoundaries {
    * @param bucketBoundaries the boundaries for the buckets in the underlying {@link Distribution}.
    * @return a new {@code BucketBoundaries} with the specified boundaries.
    * @throws NullPointerException if {@code bucketBoundaries} is null.
-   * @throws IllegalArgumentException if {@code bucketBoundaries} is not sorted, or has zero length.
+   * @throws IllegalArgumentException if {@code bucketBoundaries} is not sorted.
    */
   public static final BucketBoundaries create(List<Double> bucketBoundaries) {
     checkNotNull(bucketBoundaries, "bucketBoundaries list should not be null.");
     List<Double> bucketBoundariesCopy = new ArrayList<Double>(bucketBoundaries);  // Deep copy.
-    checkArgument(!bucketBoundariesCopy.isEmpty(), "Zero length bucket boundaries");
-    double lower = bucketBoundariesCopy.get(0);
-    for (int i = 1; i < bucketBoundariesCopy.size(); i++) {
-      double next = bucketBoundariesCopy.get(i);
-      checkArgument(lower < next, "Bucket boundaries not sorted.");
-      lower = next;
+    // Check if sorted.
+    if (bucketBoundariesCopy.size() > 1) {
+      double lower = bucketBoundariesCopy.get(0);
+      for (int i = 1; i < bucketBoundariesCopy.size(); i++) {
+        double next = bucketBoundariesCopy.get(i);
+        checkArgument(lower < next, "Bucket boundaries not sorted.");
+        lower = next;
+      }
     }
     return new AutoValue_BucketBoundaries(Collections.unmodifiableList(bucketBoundariesCopy));
   }

--- a/core/src/main/java/com/google/instrumentation/stats/Distribution.java
+++ b/core/src/main/java/com/google/instrumentation/stats/Distribution.java
@@ -42,9 +42,10 @@ import javax.annotation.concurrent.Immutable;
  * underflow bucket.
  *
  * <p>Although not forbidden, it is generally a bad idea to include non-finite values (infinities or
- * NaNs) in the population of values, as this will render the {@code mean} meaningless.
+ * NaNs) in the population of values, as this will render derived values (e.g. {@code mean})
+ * meaningless.
  */
-//  TODO(songya): needs to determine whether N = 1 is valid. (Currently we don't allow N = 1.)
+
 @Immutable
 @AutoValue
 abstract class Distribution {
@@ -63,6 +64,7 @@ abstract class Distribution {
     return new AutoValue_Distribution(
         distribution.getCount(),
         distribution.getSum(),
+        distribution.getSumSquares(),
         Range.create(distribution.getRange()),
         distribution.getBucketBoundaries(),
         bucketCounts);
@@ -94,7 +96,7 @@ abstract class Distribution {
   }
 
   /**
-   * The sum of the values in the population. If {@link #getCount()} is zero then this value must
+   * The sum of the values in the population. If {@link #getCount()} is zero then this value will
    * also be zero.
    *
    * @return The sum of values in the population.
@@ -102,8 +104,16 @@ abstract class Distribution {
   abstract double getSum();
 
   /**
-   * The range of the population values. If {@link #getCount()} is zero then this returned range is
-   * implementation-dependent.
+   * The sum of the squares of values in the population. If {@link #getCount()} is zero then this
+   * value will also be zero.
+   *
+   * @return The sum of values in the population.
+   */
+  abstract double getSumSquares();
+
+  /**
+   * The range of the population values. If {@link #getCount()} is zero then the returned range
+   * will contain [-Inf, +Inf]
    *
    * @return The {code Range} representing the range of population values.
    */
@@ -141,7 +151,6 @@ abstract class Distribution {
   abstract List<Long> getBucketCounts();
 
   /** Describes a range of population values. */
-  // TODO(sebright): Decide what to do when the distribution contains no values.
   @Immutable
   @AutoValue
   abstract static class Range {

--- a/core/src/main/java/com/google/instrumentation/stats/MutableDistribution.java
+++ b/core/src/main/java/com/google/instrumentation/stats/MutableDistribution.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 final class MutableDistribution {
   private long count = 0; // The number of values in the population.
   private double sum = 0.0; // The sum of the values in the population.
+  private double sumOfSquares = 0.0; // The sum of the sqaures of the values in the population
   private Range range = Range.create(); // Range of values in the population.
 
   @Nullable
@@ -85,13 +86,23 @@ final class MutableDistribution {
   }
 
   /**
-   * The sum of the values in the population. If {@link #getCount()} is zero then this value must
+   * The sum of the values in the population. If {@link #getCount()} is zero then this value will
    * also be zero.
    *
    * @return The sum of values in the population.
    */
   double getSum() {
     return sum;
+  }
+
+  /**
+   * The sum of the squares of values in the population. If {@link #getCount()} is zero then this
+   * value will also be zero.
+   *
+   * @return The sum of squares of values in the population.
+   */
+  double getSumSquares() {
+    return sumOfSquares;
   }
 
   /**
@@ -157,6 +168,7 @@ final class MutableDistribution {
   void add(double value) {
     count++;
     sum += value;
+    sumOfSquares += value * value;
     range.add(value);
     if (hasBuckets()) {
       putIntoBucket(value);
@@ -165,10 +177,9 @@ final class MutableDistribution {
 
   /** Mutable version of {@code Distribution.Range}. */
   static final class Range {
-    // Maintain the invariant that max should always be greater than or equal to min.
-    // TODO(songya): needs to determine how we would want to initialize min and max.
-    private Double min = null;
-    private Double max = null;
+    // Initial "impossible" values, that will get reset as soon as first value is added.
+    private double min = Double.POSITIVE_INFINITY;
+    private double max = Double.NEGATIVE_INFINITY;
 
     /** Construct a new, empty {@code Range}. */
     static final Range create() {
@@ -176,7 +187,7 @@ final class MutableDistribution {
     }
 
     /**
-     * The minimum of the population values. Will throw an exception if min has not been set.
+     * The minimum of the population values.
      *
      * @return The minimum of the population values.
      */
@@ -185,7 +196,7 @@ final class MutableDistribution {
     }
 
     /**
-     * The maximum of the population values. Will throw an exception if max has not been set.
+     * The maximum of the population values.
      *
      * @return The maximum of the population values.
      */
@@ -199,10 +210,10 @@ final class MutableDistribution {
      * @param value the new value
      */
     void add(double value) {
-      if (min == null || value < min) {
+      if (value < min) {
         min = value;
       }
-      if (max == null || value > max) {
+      if (value > max) {
         max = value;
       }
     }

--- a/core/src/test/java/com/google/instrumentation/stats/BucketBoundariesTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/BucketBoundariesTest.java
@@ -69,10 +69,10 @@ public class BucketBoundariesTest {
   }
 
   @Test
-  public void testNoBoundaries() throws Exception {
+  public void testNoBoundaries() {
     List<Double> buckets = Arrays.asList();
-    thrown.expect(IllegalArgumentException.class);
-    BucketBoundaries.create(buckets);
+    BucketBoundaries bucketBoundaries = BucketBoundaries.create(buckets);
+    assertThat(bucketBoundaries.getBoundaries()).isEqualTo(buckets);
   }
 
   @Test

--- a/core/src/test/java/com/google/instrumentation/stats/MutableDistributionTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/MutableDistributionTest.java
@@ -66,10 +66,11 @@ public class MutableDistributionTest {
   }
 
   @Test
-  public void testNoBoundaries() throws Exception {
+  public void testNoBoundaries() {
     List<Double> buckets = Arrays.asList();
-    thrown.expect(IllegalArgumentException.class);
-    MutableDistribution.create(BucketBoundaries.create(buckets));
+    MutableDistribution noBoundaries = MutableDistribution.create(BucketBoundaries.create(buckets));
+    assertThat(noBoundaries.getBucketCounts()).hasSize(1);
+    assertThat(noBoundaries.getBucketCounts().get(0)).isEqualTo(0);
   }
 
   @Test


### PR DESCRIPTION
Changes the following:
* Allows for zero-length bucketBoundaries (which creates a single bucket, both under and overflow, as documented in the original description).
* Adds a sum-of-squares (for computing variance etc.)
* Simplifies Range by not allowing null for initial values.