### PR TITLE
Create a new package for all supported propagations.

### DIFF
--- a/api/src/main/java/io/opencensus/trace/TraceComponent.java
+++ b/api/src/main/java/io/opencensus/trace/TraceComponent.java
@@ -17,10 +17,11 @@ import io.opencensus.common.Clock;
 import io.opencensus.internal.ZeroTimeClock;
 import io.opencensus.trace.config.TraceConfig;
 import io.opencensus.trace.export.ExportComponent;
+import io.opencensus.trace.propagation.PropagationComponent;
 
 /**
  * Class that holds the implementation instances for {@link Tracer}, {@link
- * BinaryPropagationHandler}, {@link Clock}, {@link ExportComponent} and {@link TraceConfig}.
+ * PropagationComponent}, {@link Clock}, {@link ExportComponent} and {@link TraceConfig}.
  *
  * <p>Unless otherwise noted all methods (on component) results are cacheable.
  */
@@ -36,12 +37,12 @@ public abstract class TraceComponent {
   public abstract Tracer getTracer();
 
   /**
-   * Returns the {@link BinaryPropagationHandler} with the provided implementations. If no
+   * Returns the {@link PropagationComponent} with the provided implementation. If no
    * implementation is provided then no-op implementation will be used.
    *
-   * @return the {@code BinaryPropagationHandler} implementation.
+   * @return the {@code PropagationComponent} implementation.
    */
-  public abstract BinaryPropagationHandler getBinaryPropagationHandler();
+  public abstract PropagationComponent getPropagationComponent();
 
   /**
    * Returns the {@link Clock} with the provided implementation.
@@ -56,7 +57,7 @@ public abstract class TraceComponent {
    *
    * @return the {@link ExportComponent} implementation.
    */
-  public abstract ExportComponent getTraceExporter();
+  public abstract ExportComponent getExportComponent();
 
   /**
    * Returns the {@link TraceConfig} with the provided implementation. If no implementation is
@@ -85,8 +86,8 @@ public abstract class TraceComponent {
     }
 
     @Override
-    public BinaryPropagationHandler getBinaryPropagationHandler() {
-      return BinaryPropagationHandler.getNoopBinaryPropagationHandler();
+    public PropagationComponent getPropagationComponent() {
+      return PropagationComponent.getNoopPropagationComponent();
     }
 
     @Override
@@ -95,7 +96,7 @@ public abstract class TraceComponent {
     }
 
     @Override
-    public ExportComponent getTraceExporter() {
+    public ExportComponent getExportComponent() {
       return ExportComponent.getNoopExportComponent();
     }
 

--- a/api/src/main/java/io/opencensus/trace/Tracing.java
+++ b/api/src/main/java/io/opencensus/trace/Tracing.java
@@ -18,6 +18,7 @@ import io.opencensus.common.Clock;
 import io.opencensus.internal.Provider;
 import io.opencensus.trace.config.TraceConfig;
 import io.opencensus.trace.export.ExportComponent;
+import io.opencensus.trace.propagation.PropagationComponent;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -37,12 +38,12 @@ public final class Tracing {
   }
 
   /**
-   * Returns the global {@link BinaryPropagationHandler}.
+   * Returns the global {@link PropagationComponent}.
    *
-   * @return the global {@code BinaryPropagationHandler}.
+   * @return the global {@code PropagationComponent}.
    */
-  public static BinaryPropagationHandler getBinaryPropagationHandler() {
-    return traceComponent.getBinaryPropagationHandler();
+  public static PropagationComponent getPropagationComponent() {
+    return traceComponent.getPropagationComponent();
   }
 
   /**
@@ -60,7 +61,7 @@ public final class Tracing {
    * @return the global {@code ExportComponent}.
    */
   public static ExportComponent getTraceExporter() {
-    return traceComponent.getTraceExporter();
+    return traceComponent.getExportComponent();
   }
 
   /**

--- a/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
@@ -11,10 +11,11 @@
  * limitations under the License.
  */
 
-package io.opencensus.trace;
+package io.opencensus.trace.propagation;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import io.opencensus.trace.SpanContext;
 import java.text.ParseException;
 
 /**
@@ -24,11 +25,11 @@ import java.text.ParseException;
  *
  * <pre>{@code
  * private static final Tracer tracer = Tracing.getTracer();
- * private static final BinaryPropagationHandler binaryPropagationHandler =
- *     Tracing.getBinaryPropagationHandler();
+ * private static final BinaryFormat binaryPropagation =
+ *     Tracing.getPropagationComponent().getBinaryFormat;
  * void onSendRequest() {
  *   try (NonThrowingCloseable ss = tracer.spanBuilder("Sent.MyRequest").startScopedSpan()) {
- *     byte[] binaryValue = binaryPropagationHandler.toBinaryValue(
+ *     byte[] binaryValue = binaryPropagation.toBinaryValue(
  *         tracer.getCurrentContext().context());
  *     // Send the request including the binaryValue and wait for the response.
  *   }
@@ -39,14 +40,14 @@ import java.text.ParseException;
  *
  * <pre>{@code
  * private static final Tracer tracer = Tracing.getTracer();
- * private static final BinaryPropagationHandler binaryPropagationHandler =
- *     Tracing.getBinaryPropagationHandler();
+ * private static final BinaryFormat binaryPropagation =
+ *     Tracing.getPropagationComponent().getBinaryFormat;
  * void onRequestReceived() {
  *   // Get the binaryValue from the request.
  *   SpanContext spanContext = SpanContext.INVALID;
  *   try {
  *     if (binaryValue != null) {
- *       spanContext = binaryPropagationHandler.fromBinaryValue(binaryValue);
+ *       spanContext = binaryPropagation.fromBinaryValue(binaryValue);
  *     }
  *   } catch (ParseException e) {
  *     // Maybe log the exception.
@@ -58,9 +59,8 @@ import java.text.ParseException;
  * }
  * }</pre>
  */
-public abstract class BinaryPropagationHandler {
-  static final NoopBinaryPropagationHandler noopBinaryPropagationHandler =
-      new NoopBinaryPropagationHandler();
+public abstract class BinaryFormat {
+  static final NoopBinaryFormat NOOP_BINARY_FORMAT = new NoopBinaryFormat();
 
   /**
    * Serializes a {@link SpanContext} using the binary format.
@@ -82,15 +82,15 @@ public abstract class BinaryPropagationHandler {
   public abstract SpanContext fromBinaryValue(byte[] bytes) throws ParseException;
 
   /**
-   * Returns the no-op implementation of the {@code BinaryPropagationHandler}.
+   * Returns the no-op implementation of the {@code BinaryFormat}.
    *
-   * @return the no-op implementation of the {@code BinaryPropagationHandler}.
+   * @return the no-op implementation of the {@code BinaryFormat}.
    */
-  static BinaryPropagationHandler getNoopBinaryPropagationHandler() {
-    return noopBinaryPropagationHandler;
+  static BinaryFormat getNoopBinaryFormat() {
+    return NOOP_BINARY_FORMAT;
   }
 
-  private static final class NoopBinaryPropagationHandler extends BinaryPropagationHandler {
+  private static final class NoopBinaryFormat extends BinaryFormat {
     @Override
     public byte[] toBinaryValue(SpanContext spanContext) {
       checkNotNull(spanContext, "spanContext");
@@ -103,6 +103,6 @@ public abstract class BinaryPropagationHandler {
       return SpanContext.INVALID;
     }
 
-    private NoopBinaryPropagationHandler() {}
+    private NoopBinaryFormat() {}
   }
 }

--- a/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
@@ -25,8 +25,8 @@ import java.text.ParseException;
  *
  * <pre>{@code
  * private static final Tracer tracer = Tracing.getTracer();
- * private static final BinaryFormat binaryPropagation =
- *     Tracing.getPropagationComponent().getBinaryFormat;
+ * private static final BinaryFormat binaryFormat =
+ *     Tracing.getPropagationComponent().getBinaryFormat();
  * void onSendRequest() {
  *   try (NonThrowingCloseable ss = tracer.spanBuilder("Sent.MyRequest").startScopedSpan()) {
  *     byte[] binaryValue = binaryPropagation.toBinaryValue(
@@ -40,8 +40,8 @@ import java.text.ParseException;
  *
  * <pre>{@code
  * private static final Tracer tracer = Tracing.getTracer();
- * private static final BinaryFormat binaryPropagation =
- *     Tracing.getPropagationComponent().getBinaryFormat;
+ * private static final BinaryFormat binaryFormat =
+ *     Tracing.getPropagationComponent().getBinaryFormat();
  * void onRequestReceived() {
  *   // Get the binaryValue from the request.
  *   SpanContext spanContext = SpanContext.INVALID;

--- a/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
@@ -29,8 +29,7 @@ import java.text.ParseException;
  *     Tracing.getPropagationComponent().getBinaryFormat();
  * void onSendRequest() {
  *   try (NonThrowingCloseable ss = tracer.spanBuilder("Sent.MyRequest").startScopedSpan()) {
- *     byte[] binaryValue = binaryPropagation.toBinaryValue(
- *         tracer.getCurrentContext().context());
+ *     byte[] binaryValue = binaryFormat.toBinaryValue(tracer.getCurrentContext().context());
  *     // Send the request including the binaryValue and wait for the response.
  *   }
  * }
@@ -47,7 +46,7 @@ import java.text.ParseException;
  *   SpanContext spanContext = SpanContext.INVALID;
  *   try {
  *     if (binaryValue != null) {
- *       spanContext = binaryPropagation.fromBinaryValue(binaryValue);
+ *       spanContext = binaryFormat.fromBinaryValue(binaryValue);
  *     }
  *   } catch (ParseException e) {
  *     // Maybe log the exception.

--- a/api/src/main/java/io/opencensus/trace/propagation/PropagationComponent.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/PropagationComponent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace.propagation;
+
+/**
+ * Container class for all the supported propagation formats. Currently supports only Binary
+ * format see {@link BinaryFormat} but more formats will be added.
+ */
+public abstract class PropagationComponent {
+  private static final PropagationComponent NOOP_PROPAGATION_COMPONENT =
+      new NoopPropagationComponent();
+
+  /**
+   * Returns the {@link BinaryFormat} with the provided implementations. If no implementation
+   * is provided then no-op implementation will be used.
+   *
+   * @return the {@code BinaryFormat} implementation.
+   */
+  public abstract BinaryFormat getBinaryFormat();
+
+  /**
+   * Returns an instance that contains no-op implementations for all the instances.
+   *
+   * @return an instance that contains no-op implementations for all the instances.
+   */
+  public static PropagationComponent getNoopPropagationComponent() {
+    return NOOP_PROPAGATION_COMPONENT;
+  }
+
+  private static final class NoopPropagationComponent extends PropagationComponent {
+    @Override
+    public BinaryFormat getBinaryFormat() {
+      return BinaryFormat.getNoopBinaryFormat();
+    }
+  }
+}

--- a/api/src/test/java/io/opencensus/trace/TraceComponentTest.java
+++ b/api/src/test/java/io/opencensus/trace/TraceComponentTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import io.opencensus.internal.ZeroTimeClock;
 import io.opencensus.trace.config.TraceConfig;
 import io.opencensus.trace.export.ExportComponent;
+import io.opencensus.trace.propagation.PropagationComponent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -32,8 +33,8 @@ public class TraceComponentTest {
 
   @Test
   public void defaultBinaryPropagationHandler() {
-    assertThat(TraceComponent.getNoopTraceComponent().getBinaryPropagationHandler())
-        .isSameAs(BinaryPropagationHandler.getNoopBinaryPropagationHandler());
+    assertThat(TraceComponent.getNoopTraceComponent().getPropagationComponent())
+        .isSameAs(PropagationComponent.getNoopPropagationComponent());
   }
 
   @Test
@@ -43,7 +44,7 @@ public class TraceComponentTest {
 
   @Test
   public void defaultTraceExporter() {
-    assertThat(TraceComponent.getNoopTraceComponent().getTraceExporter())
+    assertThat(TraceComponent.getNoopTraceComponent().getExportComponent())
         .isSameAs(ExportComponent.getNoopExportComponent());
   }
 

--- a/api/src/test/java/io/opencensus/trace/TracingTest.java
+++ b/api/src/test/java/io/opencensus/trace/TracingTest.java
@@ -17,6 +17,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.trace.config.TraceConfig;
 import io.opencensus.trace.export.ExportComponent;
+import io.opencensus.trace.propagation.PropagationComponent;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -64,8 +65,8 @@ public class TracingTest {
 
   @Test
   public void defaultBinaryPropagationHandler() {
-    assertThat(Tracing.getBinaryPropagationHandler())
-        .isSameAs(BinaryPropagationHandler.getNoopBinaryPropagationHandler());
+    assertThat(Tracing.getPropagationComponent())
+        .isSameAs(PropagationComponent.getNoopPropagationComponent());
   }
 
   @Test

--- a/api/src/test/java/io/opencensus/trace/propagation/BinaryFormatTest.java
+++ b/api/src/test/java/io/opencensus/trace/propagation/BinaryFormatTest.java
@@ -11,39 +11,39 @@
  * limitations under the License.
  */
 
-package io.opencensus.trace;
+package io.opencensus.trace.propagation;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.opencensus.trace.SpanContext;
 import java.text.ParseException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link BinaryPropagationHandler}. */
+/** Unit tests for {@link BinaryFormat}. */
 @RunWith(JUnit4.class)
-public class BinaryPropagationHandlerTest {
-  private static final BinaryPropagationHandler binaryPropagationHandler =
-      BinaryPropagationHandler.getNoopBinaryPropagationHandler();
+public class BinaryFormatTest {
+  private static final BinaryFormat BINARY_PROPAGATION =
+      BinaryFormat.getNoopBinaryFormat();
 
   @Test(expected = NullPointerException.class)
   public void toBinaryValue_NullSpanContext() {
-    binaryPropagationHandler.toBinaryValue(null);
+    BINARY_PROPAGATION.toBinaryValue(null);
   }
 
   @Test
   public void toBinaryValue_NotNullSpanContext() {
-    assertThat(binaryPropagationHandler.toBinaryValue(SpanContext.INVALID)).isEqualTo(new byte[0]);
+    assertThat(BINARY_PROPAGATION.toBinaryValue(SpanContext.INVALID)).isEqualTo(new byte[0]);
   }
 
   @Test(expected = NullPointerException.class)
   public void fromBinaryValue_NullInput() throws ParseException {
-    binaryPropagationHandler.fromBinaryValue(null);
+    BINARY_PROPAGATION.fromBinaryValue(null);
   }
 
   @Test
   public void fromBinaryValue_NotNullInput() throws ParseException {
-    assertThat(binaryPropagationHandler.fromBinaryValue(new byte[0]))
-        .isEqualTo(SpanContext.INVALID);
+    assertThat(BINARY_PROPAGATION.fromBinaryValue(new byte[0])).isEqualTo(SpanContext.INVALID);
   }
 }

--- a/api/src/test/java/io/opencensus/trace/propagation/BinaryFormatTest.java
+++ b/api/src/test/java/io/opencensus/trace/propagation/BinaryFormatTest.java
@@ -24,26 +24,26 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link BinaryFormat}. */
 @RunWith(JUnit4.class)
 public class BinaryFormatTest {
-  private static final BinaryFormat BINARY_PROPAGATION =
+  private static final BinaryFormat binaryFormat =
       BinaryFormat.getNoopBinaryFormat();
 
   @Test(expected = NullPointerException.class)
   public void toBinaryValue_NullSpanContext() {
-    BINARY_PROPAGATION.toBinaryValue(null);
+    binaryFormat.toBinaryValue(null);
   }
 
   @Test
   public void toBinaryValue_NotNullSpanContext() {
-    assertThat(BINARY_PROPAGATION.toBinaryValue(SpanContext.INVALID)).isEqualTo(new byte[0]);
+    assertThat(binaryFormat.toBinaryValue(SpanContext.INVALID)).isEqualTo(new byte[0]);
   }
 
   @Test(expected = NullPointerException.class)
   public void fromBinaryValue_NullInput() throws ParseException {
-    BINARY_PROPAGATION.fromBinaryValue(null);
+    binaryFormat.fromBinaryValue(null);
   }
 
   @Test
   public void fromBinaryValue_NotNullInput() throws ParseException {
-    assertThat(BINARY_PROPAGATION.fromBinaryValue(new byte[0])).isEqualTo(SpanContext.INVALID);
+    assertThat(binaryFormat.fromBinaryValue(new byte[0])).isEqualTo(SpanContext.INVALID);
   }
 }

--- a/api/src/test/java/io/opencensus/trace/propagation/PropagationComponentImplTest.java
+++ b/api/src/test/java/io/opencensus/trace/propagation/PropagationComponentImplTest.java
@@ -11,37 +11,23 @@
  * limitations under the License.
  */
 
-package io.opencensus.trace;
+package io.opencensus.trace.propagation;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import io.opencensus.common.MillisClock;
-import io.opencensus.trace.propagation.PropagationComponentImpl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link TraceComponentImpl}. */
+/** Unit tests for {@link PropagationComponent}. */
 @RunWith(JUnit4.class)
-public class TraceComponentImplTest {
-  @Test
-  public void implementationOfTracer() {
-    assertThat(Tracing.getTracer()).isInstanceOf(TracerImpl.class);
-  }
+public class PropagationComponentImplTest {
+  private final PropagationComponent propagationComponent =
+      PropagationComponent.getNoopPropagationComponent();
 
   @Test
-  public void implementationOfBinaryPropagationHandler() {
-    assertThat(Tracing.getPropagationComponent())
-        .isInstanceOf(PropagationComponentImpl.class);
-  }
-
-  @Test
-  public void implementationOfClock() {
-    assertThat(Tracing.getClock()).isInstanceOf(MillisClock.class);
-  }
-
-  @Test
-  public void implementationOfTraceExporter() {
-    assertThat(Tracing.getTraceExporter()).isInstanceOf(ExportComponentImpl.class);
+  public void implementationOfBinary() {
+    assertThat(propagationComponent.getBinaryFormat())
+        .isEqualTo(BinaryFormat.getNoopBinaryFormat());
   }
 }

--- a/api/src/test/java/io/opencensus/trace/propagation/PropagationComponentTest.java
+++ b/api/src/test/java/io/opencensus/trace/propagation/PropagationComponentTest.java
@@ -21,7 +21,7 @@ import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link PropagationComponent}. */
 @RunWith(JUnit4.class)
-public class PropagationComponentImplTest {
+public class PropagationComponentTest {
   private final PropagationComponent propagationComponent =
       PropagationComponent.getNoopPropagationComponent();
 

--- a/benchmarks/src/jmh/java/io/opencensus/trace/propagation/BinaryPropagationImplBenchmark.java
+++ b/benchmarks/src/jmh/java/io/opencensus/trace/propagation/BinaryPropagationImplBenchmark.java
@@ -11,8 +11,9 @@
  * limitations under the License.
  */
 
-package io.opencensus.trace;
+package io.opencensus.trace.propagation;
 
+import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.base.SpanId;
 import io.opencensus.trace.base.TraceId;
 import io.opencensus.trace.base.TraceOptions;
@@ -25,9 +26,9 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
-/** Benchmarks for {@link BinaryPropagationHandlerImpl}. */
+/** Benchmarks for {@link BinaryFormatImpl}. */
 @State(Scope.Benchmark)
-public class BinaryPropagationHandlerImplBenchmark {
+public class BinaryPropagationImplBenchmark {
   private static final byte[] traceIdBytes =
       new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'a'};
   private static final TraceId traceId = TraceId.fromBytes(traceIdBytes);
@@ -36,43 +37,42 @@ public class BinaryPropagationHandlerImplBenchmark {
   private static final byte[] traceOptionsBytes = new byte[] {1};
   private static final TraceOptions traceOptions = TraceOptions.fromBytes(traceOptionsBytes);
   private static final SpanContext spanContext = SpanContext.create(traceId, spanId, traceOptions);
-  private static final BinaryPropagationHandler binaryPropagationHandler =
-      new BinaryPropagationHandlerImpl();
+  private static final BinaryFormat BINARY_PROPAGATION = new BinaryFormatImpl();
   private static final byte[] spanContextBinary =
-      binaryPropagationHandler.toBinaryValue(spanContext);
+      BINARY_PROPAGATION.toBinaryValue(spanContext);
 
   /**
    * This benchmark attempts to measure performance of {@link
-   * BinaryPropagationHandlerImpl#toBinaryValue(SpanContext)}.
+   * BinaryFormatImpl#toBinaryValue(SpanContext)}.
    */
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public byte[] toBinaryValueSpanContext() {
-    return binaryPropagationHandler.toBinaryValue(spanContext);
+    return BINARY_PROPAGATION.toBinaryValue(spanContext);
   }
 
   /**
    * This benchmark attempts to measure performance of {@link
-   * BinaryPropagationHandlerImpl#fromBinaryValue(byte[])}.
+   * BinaryFormatImpl#fromBinaryValue(byte[])}.
    */
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public SpanContext fromBinaryValueSpanContext() throws ParseException {
-    return binaryPropagationHandler.fromBinaryValue(spanContextBinary);
+    return BINARY_PROPAGATION.fromBinaryValue(spanContextBinary);
   }
 
   /**
    * This benchmark attempts to measure performance of {@link
-   * BinaryPropagationHandlerImpl#toBinaryValue(SpanContext)} then {@link
-   * BinaryPropagationHandlerImpl#fromBinaryValue(byte[])}.
+   * BinaryFormatImpl#toBinaryValue(SpanContext)} then {@link
+   * BinaryFormatImpl#fromBinaryValue(byte[])}.
    */
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public SpanContext toFromBinarySpanContext() throws ParseException {
-    return binaryPropagationHandler.fromBinaryValue(
-        binaryPropagationHandler.toBinaryValue(spanContext));
+    return BINARY_PROPAGATION.fromBinaryValue(
+        BINARY_PROPAGATION.toBinaryValue(spanContext));
   }
 }

--- a/core_impl/src/main/java/io/opencensus/trace/TraceComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/trace/TraceComponentImplBase.java
@@ -18,12 +18,13 @@ import io.opencensus.common.EventQueue;
 import io.opencensus.trace.SpanImpl.StartEndHandler;
 import io.opencensus.trace.config.TraceConfig;
 import io.opencensus.trace.export.ExportComponent;
+import io.opencensus.trace.propagation.PropagationComponent;
+import io.opencensus.trace.propagation.PropagationComponentImpl;
 
 /** Base implementation of the {@link TraceComponent}. */
 class TraceComponentImplBase extends TraceComponent {
-  private final BinaryPropagationHandler binaryPropagationHandler =
-      new BinaryPropagationHandlerImpl();
-  private final ExportComponentImpl traceExporter = new ExportComponentImpl();
+  private final ExportComponentImpl exportComponent = new ExportComponentImpl();
+  private final PropagationComponent propagationComponent = new PropagationComponentImpl();
   private final Clock clock;
   private final StartEndHandler startEndHandler;
   private final TraceConfig traceConfig = new TraceConfigImpl();
@@ -31,7 +32,7 @@ class TraceComponentImplBase extends TraceComponent {
 
   TraceComponentImplBase(Clock clock, RandomHandler randomHandler, EventQueue eventQueue) {
     this.clock = clock;
-    startEndHandler = new StartEndHandlerImpl(traceExporter.getSpanExporter(), eventQueue);
+    startEndHandler = new StartEndHandlerImpl(exportComponent.getSpanExporter(), eventQueue);
     tracer = new TracerImpl(randomHandler, startEndHandler, clock, traceConfig);
   }
 
@@ -41,8 +42,8 @@ class TraceComponentImplBase extends TraceComponent {
   }
 
   @Override
-  public BinaryPropagationHandler getBinaryPropagationHandler() {
-    return binaryPropagationHandler;
+  public PropagationComponent getPropagationComponent() {
+    return propagationComponent;
   }
 
   @Override
@@ -51,8 +52,8 @@ class TraceComponentImplBase extends TraceComponent {
   }
 
   @Override
-  public ExportComponent getTraceExporter() {
-    return traceExporter;
+  public ExportComponent getExportComponent() {
+    return exportComponent;
   }
 
   @Override

--- a/core_impl/src/main/java/io/opencensus/trace/propagation/BinaryFormatImpl.java
+++ b/core_impl/src/main/java/io/opencensus/trace/propagation/BinaryFormatImpl.java
@@ -11,19 +11,20 @@
  * limitations under the License.
  */
 
-package io.opencensus.trace;
+package io.opencensus.trace.propagation;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.base.SpanId;
 import io.opencensus.trace.base.TraceId;
 import io.opencensus.trace.base.TraceOptions;
 import java.text.ParseException;
 
 /**
- * Implementation of the {@link BinaryPropagationHandler}.
+ * Implementation of the {@link BinaryFormat}.
  *
- * <p>Binary format:
+ * <p>BinaryFormat format:
  *
  * <ul>
  *   <li>Binary value: &lt;version_id&gt;&lt;version_format&gt;
@@ -54,7 +55,7 @@ import java.text.ParseException;
  *       </ul>
  * </ul>
  */
-final class BinaryPropagationHandlerImpl extends BinaryPropagationHandler {
+final class BinaryFormatImpl extends BinaryFormat {
   private static final byte VERSION_ID = 0;
   private static final int VERSION_ID_OFFSET = 0;
   // The version_id/field_id size in bytes.
@@ -71,7 +72,7 @@ final class BinaryPropagationHandlerImpl extends BinaryPropagationHandler {
   private static final int FORMAT_LENGTH =
       4 * ID_SIZE + TraceId.SIZE + SpanId.SIZE + TraceOptions.SIZE;
 
-  BinaryPropagationHandlerImpl() {}
+  BinaryFormatImpl() {}
 
   @Override
   public byte[] toBinaryValue(SpanContext spanContext) {

--- a/core_impl/src/main/java/io/opencensus/trace/propagation/PropagationComponentImpl.java
+++ b/core_impl/src/main/java/io/opencensus/trace/propagation/PropagationComponentImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace.propagation;
+
+/** Implementation of the {@link PropagationComponent}. */
+public class PropagationComponentImpl extends PropagationComponent {
+  private final BinaryFormat binaryFormat = new BinaryFormatImpl();
+
+  @Override
+  public BinaryFormat getBinaryFormat() {
+    return binaryFormat;
+  }
+}

--- a/core_impl/src/test/java/io/opencensus/trace/TraceComponentImplBaseTest.java
+++ b/core_impl/src/test/java/io/opencensus/trace/TraceComponentImplBaseTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import io.opencensus.common.MillisClock;
 import io.opencensus.common.SimpleEventQueue;
 import io.opencensus.trace.RandomHandler.SecureRandomHandler;
+import io.opencensus.trace.propagation.PropagationComponentImpl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -36,8 +37,8 @@ public class TraceComponentImplBaseTest {
 
   @Test
   public void implementationOfBinaryPropagationHandler() {
-    assertThat(traceComponent.getBinaryPropagationHandler())
-        .isInstanceOf(BinaryPropagationHandlerImpl.class);
+    assertThat(traceComponent.getPropagationComponent())
+        .isInstanceOf(PropagationComponentImpl.class);
   }
 
   @Test
@@ -47,6 +48,6 @@ public class TraceComponentImplBaseTest {
 
   @Test
   public void implementationOfTraceExporter() {
-    assertThat(traceComponent.getTraceExporter()).isInstanceOf(ExportComponentImpl.class);
+    assertThat(traceComponent.getExportComponent()).isInstanceOf(ExportComponentImpl.class);
   }
 }

--- a/core_impl/src/test/java/io/opencensus/trace/propagation/PropagationComponentImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/trace/propagation/PropagationComponentImplTest.java
@@ -11,37 +11,22 @@
  * limitations under the License.
  */
 
-package io.opencensus.trace;
+package io.opencensus.trace.propagation;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import io.opencensus.common.MillisClock;
-import io.opencensus.trace.propagation.PropagationComponentImpl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link TraceComponentImpl}. */
+/** Unit tests for {@link PropagationComponentImpl}. */
 @RunWith(JUnit4.class)
-public class TraceComponentImplTest {
-  @Test
-  public void implementationOfTracer() {
-    assertThat(Tracing.getTracer()).isInstanceOf(TracerImpl.class);
-  }
+public class PropagationComponentImplTest {
+  private final PropagationComponent propagationComponent = new PropagationComponentImpl();
 
   @Test
-  public void implementationOfBinaryPropagationHandler() {
-    assertThat(Tracing.getPropagationComponent())
-        .isInstanceOf(PropagationComponentImpl.class);
-  }
-
-  @Test
-  public void implementationOfClock() {
-    assertThat(Tracing.getClock()).isInstanceOf(MillisClock.class);
-  }
-
-  @Test
-  public void implementationOfTraceExporter() {
-    assertThat(Tracing.getTraceExporter()).isInstanceOf(ExportComponentImpl.class);
+  public void implementationOfBinary() {
+    assertThat(propagationComponent.getBinaryFormat())
+        .isInstanceOf(BinaryFormatImpl.class);
   }
 }

--- a/core_impl_java/src/test/java/io/opencensus/trace/TracingTest.java
+++ b/core_impl_java/src/test/java/io/opencensus/trace/TracingTest.java
@@ -16,6 +16,7 @@ package io.opencensus.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.common.MillisClock;
+import io.opencensus.trace.propagation.PropagationComponent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -30,8 +31,8 @@ public class TracingTest {
 
   @Test
   public void implementationOfBinaryPropagationHandler() {
-    assertThat(Tracing.getBinaryPropagationHandler())
-        .isInstanceOf(BinaryPropagationHandlerImpl.class);
+    assertThat(Tracing.getPropagationComponent())
+        .isInstanceOf(PropagationComponent.class);
   }
 
   @Test


### PR DESCRIPTION
This change allows the library to add support for multiple formats without changing the Tracing class, and without polluting the main package (io.opencensus).

PR summary:
* Rename BinaryPropagationHandler -> BinaryFormat and move it to propagation package.
* Add a PropagationComponent as a container for all format implementations.
* Change Tracing/TraceComponent to return PropagationComponent instead of directly the BinaryFormat.
* Move benchmarks for BinaryFormat in propagation package.
