### PR TITLE
Move SpanData to export package. Move implementation of export package class to export package.

### DIFF
--- a/api/src/main/java/io/opencensus/internal/package-info.java
+++ b/api/src/main/java/io/opencensus/internal/package-info.java
@@ -12,7 +12,7 @@
  */
 
 /**
- * Interfaces and implementations that are internal to opencensus.
+ * Interfaces and implementations that are internal to OpenCensus.
  *
  * <p>All the content under this package and its subpackages are considered annotated with {@link
  * io.opencensus.common.Internal}.

--- a/api/src/main/java/io/opencensus/trace/export/InProcessDebuggingHandler.java
+++ b/api/src/main/java/io/opencensus/trace/export/InProcessDebuggingHandler.java
@@ -18,7 +18,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auto.value.AutoValue;
 import io.opencensus.trace.Span;
-import io.opencensus.trace.SpanData;
 import io.opencensus.trace.base.Status;
 import io.opencensus.trace.base.Status.CanonicalCode;
 import java.util.Collection;

--- a/api/src/main/java/io/opencensus/trace/export/SpanData.java
+++ b/api/src/main/java/io/opencensus/trace/export/SpanData.java
@@ -11,12 +11,14 @@
  * limitations under the License.
  */
 
-package io.opencensus.trace;
+package io.opencensus.trace.export;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auto.value.AutoValue;
 import io.opencensus.common.Timestamp;
+import io.opencensus.trace.Span;
+import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.base.Annotation;
 import io.opencensus.trace.base.AttributeValue;
 import io.opencensus.trace.base.Link;

--- a/api/src/main/java/io/opencensus/trace/export/SpanExporter.java
+++ b/api/src/main/java/io/opencensus/trace/export/SpanExporter.java
@@ -14,7 +14,6 @@
 package io.opencensus.trace.export;
 
 import io.opencensus.trace.Span;
-import io.opencensus.trace.SpanData;
 import io.opencensus.trace.base.TraceOptions;
 import java.util.Collection;
 import java.util.logging.Level;

--- a/api/src/test/java/io/opencensus/trace/export/ExportComponentTest.java
+++ b/api/src/test/java/io/opencensus/trace/export/ExportComponentTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace.export;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link ExportComponent}. */
+@RunWith(JUnit4.class)
+public class ExportComponentTest {
+  private final ExportComponent exportComponent = ExportComponent.getNoopExportComponent();
+
+  @Test
+  public void implementationOfSpanExporter() {
+    assertThat(exportComponent.getSpanExporter()).isEqualTo(SpanExporter.getNoopSpanExporter());
+  }
+
+  @Test
+  public void implementationOfInProcessDebuggingHandler() {
+    assertThat(exportComponent.getInProcessDebuggingHandler()).isNull();
+  }
+}

--- a/api/src/test/java/io/opencensus/trace/export/SpanDataTest.java
+++ b/api/src/test/java/io/opencensus/trace/export/SpanDataTest.java
@@ -11,25 +11,26 @@
  * limitations under the License.
  */
 
-package io.opencensus.trace;
+package io.opencensus.trace.export;
 
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
 import io.opencensus.common.Timestamp;
-import io.opencensus.trace.base.Link;
-import io.opencensus.trace.base.Link.Type;
-import io.opencensus.trace.SpanData.Attributes;
-import io.opencensus.trace.SpanData.Links;
-import io.opencensus.trace.SpanData.TimedEvent;
-import io.opencensus.trace.SpanData.TimedEvents;
+import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.base.Annotation;
 import io.opencensus.trace.base.AttributeValue;
+import io.opencensus.trace.base.Link;
+import io.opencensus.trace.base.Link.Type;
 import io.opencensus.trace.base.NetworkEvent;
 import io.opencensus.trace.base.SpanId;
 import io.opencensus.trace.base.Status;
 import io.opencensus.trace.base.TraceId;
 import io.opencensus.trace.base.TraceOptions;
+import io.opencensus.trace.export.SpanData.Attributes;
+import io.opencensus.trace.export.SpanData.Links;
+import io.opencensus.trace.export.SpanData.TimedEvent;
+import io.opencensus.trace.export.SpanData.TimedEvents;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;

--- a/core_impl/src/main/java/io/opencensus/trace/StartEndHandlerImpl.java
+++ b/core_impl/src/main/java/io/opencensus/trace/StartEndHandlerImpl.java
@@ -15,16 +15,18 @@ package io.opencensus.trace;
 
 import io.opencensus.internal.EventQueue;
 import io.opencensus.trace.SpanImpl.StartEndHandler;
+import io.opencensus.trace.export.SpanData;
+import io.opencensus.trace.export.SpanExporterImpl;
 
 /**
  * Uses the provided {@link EventQueue} to defer processing/exporting of the {@link SpanData} to
  * avoid impacting the critical path.
  */
-final class StartEndHandlerImpl implements StartEndHandler {
+public final class StartEndHandlerImpl implements StartEndHandler {
   private final EventQueue eventQueue;
   private final SpanExporterImpl sampledSpansServiceExporter;
 
-  StartEndHandlerImpl(
+  public StartEndHandlerImpl(
       SpanExporterImpl sampledSpansServiceExporter, EventQueue eventQueue) {
     this.sampledSpansServiceExporter = sampledSpansServiceExporter;
     this.eventQueue = eventQueue;

--- a/core_impl/src/main/java/io/opencensus/trace/TraceComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/trace/TraceComponentImplBase.java
@@ -19,6 +19,7 @@ import io.opencensus.trace.SpanImpl.StartEndHandler;
 import io.opencensus.trace.config.TraceConfig;
 import io.opencensus.trace.config.TraceConfigImpl;
 import io.opencensus.trace.export.ExportComponent;
+import io.opencensus.trace.export.ExportComponentImpl;
 import io.opencensus.trace.internal.RandomHandler;
 import io.opencensus.trace.propagation.PropagationComponent;
 import io.opencensus.trace.propagation.PropagationComponentImpl;

--- a/core_impl/src/main/java/io/opencensus/trace/export/ExportComponentImpl.java
+++ b/core_impl/src/main/java/io/opencensus/trace/export/ExportComponentImpl.java
@@ -11,12 +11,10 @@
  * limitations under the License.
  */
 
-package io.opencensus.trace;
+package io.opencensus.trace.export;
 
 import io.opencensus.internal.EventQueue;
 import io.opencensus.trace.SpanImpl.StartEndHandler;
-import io.opencensus.trace.export.ExportComponent;
-import io.opencensus.trace.export.InProcessDebuggingHandler;
 import javax.annotation.Nullable;
 
 /**
@@ -25,7 +23,7 @@ import javax.annotation.Nullable;
  * <p>Uses the provided {@link EventQueue} to defer processing/exporting of the {@link SpanData} to
  * avoid impacting the critical path.
  */
-final class ExportComponentImpl extends ExportComponent {
+public final class ExportComponentImpl extends ExportComponent {
   private static final int EXPORTER_BUFFER_SIZE = 32;
   // Enforces that trace export exports data at least once every 2 seconds.
   private static final long EXPORTER_SCHEDULE_DELAY_MS = 2000;
@@ -44,7 +42,8 @@ final class ExportComponentImpl extends ExportComponent {
     return null;
   }
 
-  ExportComponentImpl() {
+  /** Constructs a new {@code ExportComponentImpl}. */
+  public ExportComponentImpl() {
     this.spanExporter = SpanExporterImpl.create(EXPORTER_BUFFER_SIZE, EXPORTER_SCHEDULE_DELAY_MS);
   }
 }

--- a/core_impl/src/main/java/io/opencensus/trace/export/SpanExporterImpl.java
+++ b/core_impl/src/main/java/io/opencensus/trace/export/SpanExporterImpl.java
@@ -11,11 +11,10 @@
  * limitations under the License.
  */
 
-package io.opencensus.trace;
+package io.opencensus.trace.export;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.opencensus.trace.export.ExportComponent;
-import io.opencensus.trace.export.SpanExporter;
+import io.opencensus.trace.SpanImpl;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -49,8 +48,12 @@ public final class SpanExporterImpl extends SpanExporter {
     return new SpanExporterImpl(workerThread);
   }
 
-  // Adds a Span to the exporting service.
-  void addSpan(SpanImpl span) {
+  /**
+   * Adds a Span to the exporting service.
+   *
+   * @param span the {@code Span} to be added.
+   */
+  public void addSpan(SpanImpl span) {
     workerThread.addSpan(span);
   }
 

--- a/core_impl/src/test/java/io/opencensus/trace/SpanFactoryImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/trace/SpanFactoryImplTest.java
@@ -25,6 +25,7 @@ import io.opencensus.trace.base.TraceId;
 import io.opencensus.trace.base.TraceOptions;
 import io.opencensus.trace.config.TraceConfig;
 import io.opencensus.trace.config.TraceParams;
+import io.opencensus.trace.export.SpanData;
 import io.opencensus.trace.internal.RandomHandler;
 import io.opencensus.trace.samplers.Samplers;
 import java.util.Random;

--- a/core_impl/src/test/java/io/opencensus/trace/SpanImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/trace/SpanImplTest.java
@@ -31,6 +31,7 @@ import io.opencensus.trace.base.Status;
 import io.opencensus.trace.base.TraceId;
 import io.opencensus.trace.base.TraceOptions;
 import io.opencensus.trace.config.TraceParams;
+import io.opencensus.trace.export.SpanData;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;

--- a/core_impl/src/test/java/io/opencensus/trace/TraceComponentImplBaseTest.java
+++ b/core_impl/src/test/java/io/opencensus/trace/TraceComponentImplBaseTest.java
@@ -17,6 +17,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.common.MillisClock;
 import io.opencensus.internal.SimpleEventQueue;
+import io.opencensus.trace.export.ExportComponentImpl;
 import io.opencensus.trace.internal.RandomHandler.SecureRandomHandler;
 import io.opencensus.trace.propagation.PropagationComponentImpl;
 import org.junit.Test;

--- a/core_impl/src/test/java/io/opencensus/trace/export/ExportComponentImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/trace/export/ExportComponentImplTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace.export;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link ExportComponentImpl}. */
+@RunWith(JUnit4.class)
+public class ExportComponentImplTest {
+  private final ExportComponent exportComponent = new ExportComponentImpl();
+
+  @Test
+  public void implementationOfSpanExporter() {
+    assertThat(exportComponent.getSpanExporter()).isInstanceOf(SpanExporterImpl.class);
+  }
+
+  @Test
+  public void implementationOfInProcessDebuggingHandler() {
+    assertThat(exportComponent.getInProcessDebuggingHandler()).isNull();
+  }
+}

--- a/core_impl/src/test/java/io/opencensus/trace/export/SpanExporterImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/trace/export/SpanExporterImplTest.java
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package io.opencensus.trace;
+package io.opencensus.trace.export;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Matchers.anyListOf;
@@ -20,7 +20,10 @@ import static org.mockito.Mockito.doThrow;
 import io.opencensus.common.MillisClock;
 import io.opencensus.internal.SimpleEventQueue;
 import io.opencensus.trace.Span.Options;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.SpanImpl;
 import io.opencensus.trace.SpanImpl.StartEndHandler;
+import io.opencensus.trace.StartEndHandlerImpl;
 import io.opencensus.trace.base.SpanId;
 import io.opencensus.trace.base.TraceId;
 import io.opencensus.trace.base.TraceOptions;

--- a/core_impl_android/src/test/java/io/opencensus/trace/TraceComponentImplTest.java
+++ b/core_impl_android/src/test/java/io/opencensus/trace/TraceComponentImplTest.java
@@ -16,6 +16,7 @@ package io.opencensus.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.common.MillisClock;
+import io.opencensus.trace.export.ExportComponentImpl;
 import io.opencensus.trace.propagation.PropagationComponentImpl;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/core_impl_java/src/test/java/io/opencensus/trace/TracingTest.java
+++ b/core_impl_java/src/test/java/io/opencensus/trace/TracingTest.java
@@ -16,6 +16,7 @@ package io.opencensus.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.common.MillisClock;
+import io.opencensus.trace.export.ExportComponentImpl;
 import io.opencensus.trace.propagation.PropagationComponent;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
More cleanups included:

* Add internal annotation to all implementation classes.
* Fix javadoc export for implementation (avoid exporting io.opencensus.internal).