### PR TITLE
Add a skeleton Java agent

### DIFF
--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -1,0 +1,40 @@
+plugins {
+  id 'com.github.johnrengelman.shadow' version '2.0.0'
+}
+
+description = 'OpenCensus Agent'
+
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+def agentPackage = 'io.opencensus.contrib.agent'
+def agentMainClass = "${agentPackage}.AgentMain"
+
+dependencies {
+  compile group: 'net.bytebuddy', name: 'byte-buddy', version: '1.7.1'
+
+  signature 'org.codehaus.mojo.signature:java17:+@signature'
+}
+
+jar {
+  // Set required manifest attributes, cf.
+  // https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/package-summary.html.
+  manifest {
+    attributes 'Premain-Class': agentMainClass
+    attributes 'Can-Retransform-Classes': true
+  }
+}
+
+// Bundle the agent's classes and dependencies into a single, self-contained JAR file.
+shadowJar {
+  // Output to opencensus-agent-VERSION.jar.
+  baseName = 'opencensus-agent'
+  classifier = null
+
+  // TODO(stschmidt): Relocate third party packages to avoid any conflicts of the agent's classes
+  // with the app's classes, which are loaded by the same classloader (the system classloader).
+
+  // TODO(stschmidt): Assert that there's nothing unexpected left outside of ${agentPackage}.
+}
+
+jar.finalizedBy shadowJar

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentBuilderListener.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentBuilderListener.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.contrib.agent;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.utility.JavaModule;
+
+/**
+ * An {@link AgentBuilder.Listener} which uses {@link java.util.logging} for logging events of
+ * interest.
+ */
+final class AgentBuilderListener implements AgentBuilder.Listener {
+
+  private static final Logger logger = Logger.getLogger(AgentBuilderListener.class.getName());
+
+  @Override
+  public void onTransformation(
+          TypeDescription typeDescription,
+          ClassLoader classLoader,
+          JavaModule module,
+          boolean loaded,
+          DynamicType dynamicType) {
+    logger.log(Level.FINE, "{0}", typeDescription);
+  }
+
+  @Override
+  public void onIgnored(
+          TypeDescription typeDescription,
+          ClassLoader classLoader,
+          JavaModule module,
+          boolean loaded) {
+  }
+
+  @Override
+  public void onError(
+          String typeName,
+          ClassLoader classLoader,
+          JavaModule module,
+          boolean loaded,
+          Throwable throwable) {
+    logger.log(Level.WARNING, "Failed to handle " + typeName, throwable);
+  }
+
+  @Override
+  public void onComplete(
+          String typeName,
+          ClassLoader classLoader,
+          JavaModule module,
+          boolean loaded) {
+  }
+
+  @Override
+  public void onDiscovery(String typeName,
+          ClassLoader classLoader,
+          JavaModule module,
+          boolean loaded) {
+  }
+}

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.contrib.agent;
+
+import static net.bytebuddy.matcher.ElementMatchers.none;
+
+import java.lang.instrument.Instrumentation;
+import java.util.logging.Logger;
+import net.bytebuddy.agent.builder.AgentBuilder;
+
+/**
+ * The <b>OpenCensus Agent for Java</b> collects and sends latency data about your Java
+ * process to OpenCensus backends such as Stackdriver Trace for analysis and visualization.
+ *
+ * <p>To enable the *OpenCensus Agent for Java* for your application, add the option
+ * <code>-javaagent:path/to/opencensus-agent.jar</code> to the invocation of the
+ * <code>java</code> executable as shown in the following example:
+ *
+ * <pre>
+ * java -javaagent:path/to/opencensus-agent.jar ...
+ * </pre>
+ *
+ * @see <a href="https://github.com/census-instrumentation/instrumentation-java/tree/master/agent">https://github.com/census-instrumentation/instrumentation-java/tree/master/agent</a>
+ */
+public final class AgentMain {
+
+  private static final Logger logger = Logger.getLogger(AgentMain.class.getName());
+
+  private AgentMain() {
+  }
+
+  /**
+   * Initializes the OpenCensus Agent for Java.
+   *
+   * @param agentArgs agent options, passed as a single string by the JVM
+   * @param inst      the {@link Instrumentation} object provided by the JVM for instrumenting Java
+   *                  programming language code
+   * @throws Exception if initialization of the agent fails
+   *
+   * @see java.lang.instrument
+   */
+  public static void premain(String agentArgs, Instrumentation inst) throws Exception {
+    logger.info("Initializing.");
+
+    AgentBuilder agentBuilder = new AgentBuilder.Default()
+            .disableClassFormatChanges()
+            .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+            .with(new AgentBuilderListener())
+            .ignore(none());
+    // TODO(stschmidt): Add instrumentation for context propagation.
+    agentBuilder.installOn(inst);
+
+    logger.info("Initialized.");
+  }
+}


### PR DESCRIPTION
Add a skeleton Java agent, which hooks up Bytebuddy, but doesn't do anything yet besides logging. Also add it to the build process, bundling the required classes and dependencies in a single agent JAR file.